### PR TITLE
Environment setup fixes

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,9 +5,8 @@ channels:
 dependencies:
   - python=3.7.6
   - pinocchio=2.3.1
+  - urdfdom=1.0.4
   - assimp=4.1.0
-  - pytorch=1.3.1=py3.7_cuda10.1.243_cudnn7.6.3_0
-  - torchvision=0.4.2=py37_cu101
   - rclone=1.52.3
   - gxx_linux-64=7.3.0
   - git-lfs=2.11.0
@@ -20,8 +19,10 @@ dependencies:
   - pillow=6.0.0
   - ipython
   - pip:
-      - ./deps/bullet3
       - ./deps/job-runner
+      - torch
+      - torchvision
+      - pybullet
       - imageio==2.6.1
       - simplejson==3.17.0
       - opencv-python==4.1.2.30


### PR DESCRIPTION
The current conda environment is a bit brittle and did not work for my system (Ubuntu 22.04, CUDA 11.8, RTX 3090). So I've suggested three changes in this pull request:
* Installing the most recent `torch` and `torchvision` via pip
* Installing the latest `pybullet` instead of building `./deps/bullet3`
* Adding `urdfdom=1.0.4` to support `pinocchio`

I have tested this setup using `cosypose.scripts.run_cosypose_eval` and `cosypose.scripts.run_bop_eval`, but it's certainly possible that other scripts may fail. If you have other tests that you would like me to perform to validate this PR, please let me know!