### PR TITLE
Meshlab arguments

### DIFF
--- a/cosypose/libmesh/meshlab_converter.py
+++ b/cosypose/libmesh/meshlab_converter.py
@@ -23,10 +23,11 @@ def run_meshlab_script(in_path, out_path, script, cd_dir=None, has_textures=True
         cd_dir = '.'
     command = [f'cd {cd_dir} &&', 'LC_ALL=C',
                'meshlabserver', '-i', in_path.as_posix(), '-o', out_path.as_posix(),
-               '-s', script_path.as_posix(), '-om', 'vn']
+               '-m', 'vn']
     if has_textures:
         command += ['wt', 'vt']
-    print(command)
+    command += ['-s', script_path.as_posix()]
+    print(('-'*40) + '\n' + ' '.join(command) + '\n' + ('-'*40))
     os.system(' '.join(command))
     script_path.unlink()
     return

--- a/cosypose/libmesh/meshlab_converter.py
+++ b/cosypose/libmesh/meshlab_converter.py
@@ -27,7 +27,7 @@ def run_meshlab_script(in_path, out_path, script, cd_dir=None, has_textures=True
     if has_textures:
         command += ['wt', 'vt']
     command += ['-s', script_path.as_posix()]
-    print(('-'*40) + '\n' + ' '.join(command) + '\n' + ('-'*40))
+    print(' '.join(command) + '\n')
     os.system(' '.join(command))
     script_path.unlink()
     return


### PR DESCRIPTION
I changed the arguments to `meshlabserver` to reflect recent updates to MeshLab. The edited script is used to generate URDF versions of meshes.