### PR TITLE
Add HOPE dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ where model_id is given by the table below:
 | ycbv    | refiner    | SYNT+REAL       | refiner-bop-ycbv-synt+real--631598   |
 |         |            |                 |                                      |
 | hope    | detector   | PBR             | detector-bop-hope-pbr--15246         |
-| hope    | coarse     | PBR             | coarse-bop-hope-pbr-225203           |
+| hope    | coarse     | PBR             | coarse-bop-hope-pbr--225203          |
 | hope    | refiner    | PBR             | refiner-bop-hope-pbr--955392         |
 
 The detectors are MaskRCNN models with resnet50 FPN backbone. PBR corresponds to training only on provided synthetic images. SYNT+REAL corresponds to training on all available synthetic and real images when available (only for tless, tudl and ycbv). SYNT+REAL models are pre-trained from PBR.

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Notes:
 <details>
 <summary>Click for details...</summary>
 
-We provide the training code that we used to train single-view single-object pose estimation models on the 7 core datasets (LM-O, TLESS, TUD-L, IC-BIN, ITODD, HB, YCB-V) and pre-trained detector and pose estimation models. Note that these models are different from the ones used in the paper. The differences with the models used in the paper are the following:
+We provide the training code that we used to train single-view single-object pose estimation models on the 7 core datasets (LM-O, TLESS, TUD-L, IC-BIN, ITODD, HB, YCB-V) and pre-trained detector and pose estimation models (core datasets + HOPE). Note that these models are different from the ones used in the paper. The differences with the models used in the paper are the following:
 
 - In the paper, we use already available detectors for T-LESS and YCB-Video. For the BOP20 challenge, we trained our own detectors on each dataset.
 - Detection and pose estimation models are trained using PBR synthetic images provided with the BOP challenge instead of using our own synthetic data to make it easier to compare fairly with the other approaches.
@@ -524,7 +524,7 @@ python -m cosypose.scripts.download --bop_dataset=DATASET --pbr_training_images
 python -m cosypose.scripts.download --urdf_models=DATASET
 ```
 
-for DATASET={hb,icbin,itodd,lm,lmo,tless,tudl,ycbv}. If you are not interested in training the models, you can remove the flag --pbr_training_images and you can omit lm.
+for DATASET={hb,icbin,itodd,lm,lmo,tless,tudl,ycbv,hope}. If you are not interested in training the models, you can remove the flag --pbr_training_images and you can omit lm.
 
 ## Downloading pre-trained models
 
@@ -574,6 +574,10 @@ where model_id is given by the table below:
 | ycbv    | detector   | SYNT+REAL       | detector-bop-ycbv-synt+real--292971  |
 | ycbv    | coarse     | SYNT+REAL       | coarse-bop-ycbv-synt+real--822463    |
 | ycbv    | refiner    | SYNT+REAL       | refiner-bop-ycbv-synt+real--631598   |
+|         |            |                 |                                      |
+| hope    | detector   | PBR             | detector-bop-hope-pbr--15246         |
+| hope    | coarse     | PBR             | coarse-bop-hope-pbr-225203           |
+| hope    | refiner    | PBR             | refiner-bop-hope-pbr--955392         |
 
 The detectors are MaskRCNN models with resnet50 FPN backbone. PBR corresponds to training only on provided synthetic images. SYNT+REAL corresponds to training on all available synthetic and real images when available (only for tless, tudl and ycbv). SYNT+REAL models are pre-trained from PBR.
 

--- a/cosypose/bop_config.py
+++ b/cosypose/bop_config.py
@@ -99,7 +99,7 @@ PBR_COARSE = dict(
     tless='coarse-bop-tless-pbr--506801',
     tudl='coarse-bop-tudl-pbr--373484',
     ycbv='coarse-bop-ycbv-pbr--724183',
-    hope='coarse-bop-hope-pbr-225203',
+    hope='coarse-bop-hope-pbr--225203',
 )
 
 PBR_REFINER = dict(

--- a/cosypose/bop_config.py
+++ b/cosypose/bop_config.py
@@ -59,7 +59,6 @@ BOP_CONFIG['tudl'] = dict(
     train_synt_real_ds_names=[('tudl.pbr', 10), ('tudl.train.real', 1)]
 )
 
-
 BOP_CONFIG['ycbv'] = dict(
     input_resize=(640, 480),
     urdf_ds_name='ycbv',
@@ -71,6 +70,16 @@ BOP_CONFIG['ycbv'] = dict(
     train_synt_real_ds_names=[('ycbv.pbr', 20), ('ycbv.train.synt', 1), ('ycbv.train.real', 3)]
 )
 
+BOP_CONFIG['hope'] = dict(
+    input_resize=(640, 480),
+    urdf_ds_name='hope',
+    obj_ds_name='hope.bop',
+    train_pbr_ds_name=['hope.pbr'],
+    inference_ds_name=['hope.bop19'],
+    test_ds_name=['hope.bop19'],
+    val_ds_name=['hope.val'],
+)
+
 PBR_DETECTORS = dict(
     hb='detector-bop-hb-pbr--497808',
     icbin='detector-bop-icbin-pbr--947409',
@@ -79,6 +88,7 @@ PBR_DETECTORS = dict(
     tless='detector-bop-tless-pbr--873074',
     tudl='detector-bop-tudl-pbr--728047',
     ycbv='detector-bop-ycbv-pbr--970850',
+    hope='detector-bop-hope-pbr--15246',
 )
 
 PBR_COARSE = dict(
@@ -89,6 +99,7 @@ PBR_COARSE = dict(
     tless='coarse-bop-tless-pbr--506801',
     tudl='coarse-bop-tudl-pbr--373484',
     ycbv='coarse-bop-ycbv-pbr--724183',
+    hope='coarse-bop-hope-pbr-225203',
 )
 
 PBR_REFINER = dict(
@@ -99,6 +110,7 @@ PBR_REFINER = dict(
     tless='refiner-bop-tless-pbr--233420',
     tudl='refiner-bop-tudl-pbr--487212',
     ycbv='refiner-bop-ycbv-pbr--604090',
+    hope='refiner-bop-hope-pbr--955392',
 )
 
 SYNT_REAL_DETECTORS = dict(

--- a/cosypose/bop_config.py
+++ b/cosypose/bop_config.py
@@ -71,10 +71,10 @@ BOP_CONFIG['ycbv'] = dict(
 )
 
 BOP_CONFIG['hope'] = dict(
-    input_resize=(640, 480),
+    input_resize=(1920, 1080),
     urdf_ds_name='hope',
     obj_ds_name='hope.bop',
-    train_pbr_ds_name=['hope.pbr'],
+    # train_pbr_ds_name=[hope.pbr],
     inference_ds_name=['hope.bop19'],
     test_ds_name=['hope.bop19'],
     val_ds_name=['hope.val'],

--- a/cosypose/datasets/datasets_cfg.py
+++ b/cosypose/datasets/datasets_cfg.py
@@ -97,6 +97,10 @@ def make_scene_dataset(ds_name, n_frames=None):
         ds_dir = BOP_DS_DIR / 'ycbv'
         ds = BOPDataset(ds_dir, split='test')
         ds = keep_bop19(ds)
+    elif ds_name == 'hope.bop19':
+        ds_dir = BOP_DS_DIR / 'hope'
+        ds = BOPDataset(ds_dir, split='test')
+        ds = keep_bop19(ds)
 
     elif ds_name == 'hb.pbr':
         ds_dir = BOP_DS_DIR / 'hb'
@@ -119,6 +123,9 @@ def make_scene_dataset(ds_name, n_frames=None):
     elif ds_name == 'ycbv.pbr':
         ds_dir = BOP_DS_DIR / 'ycbv'
         ds = BOPDataset(ds_dir, split='train_pbr')
+    elif ds_name == 'hope.pbr':
+        ds_dir = BOP_DS_DIR / 'hope'
+        ds = BOPDataset(ds_dir, split='train_pbr')
 
     elif ds_name == 'hb.val':
         ds_dir = BOP_DS_DIR / 'hb'
@@ -126,6 +133,10 @@ def make_scene_dataset(ds_name, n_frames=None):
     elif ds_name == 'itodd.val':
         ds_dir = BOP_DS_DIR / 'itodd'
         ds = BOPDataset(ds_dir, split='val')
+    elif ds_name == 'hope.val':
+        ds_dir = BOP_DS_DIR / 'hope'
+        ds = BOPDataset(ds_dir, split='val')
+    
     elif ds_name == 'tudl.train.real':
         ds_dir = BOP_DS_DIR / 'tudl'
         ds = BOPDataset(ds_dir, split='train_real')
@@ -176,6 +187,8 @@ def make_object_dataset(ds_name):
         ds = BOPObjectDataset(BOP_DS_DIR / 'lm/models')
     elif ds_name == 'tudl':
         ds = BOPObjectDataset(BOP_DS_DIR / 'tudl/models')
+    elif ds_name == 'hope':
+        ds = BOPObjectDataset(BOP_DS_DIR / 'hope/models')
 
     else:
         raise ValueError(ds_name)
@@ -208,6 +221,8 @@ def make_urdf_dataset(ds_name):
         ds = BOPUrdfDataset(LOCAL_DATA_DIR / 'urdfs' / 'lm')
     elif ds_name == 'tudl':
         ds = BOPUrdfDataset(LOCAL_DATA_DIR / 'urdfs' / 'tudl')
+    elif ds_name == 'hope':
+        ds = BOPUrdfDataset(LOCAL_DATA_DIR / 'urdfs' / 'hope')
 
     # Custom scenario
     elif 'custom' in ds_name:

--- a/cosypose/datasets/datasets_cfg.py
+++ b/cosypose/datasets/datasets_cfg.py
@@ -123,9 +123,9 @@ def make_scene_dataset(ds_name, n_frames=None):
     elif ds_name == 'ycbv.pbr':
         ds_dir = BOP_DS_DIR / 'ycbv'
         ds = BOPDataset(ds_dir, split='train_pbr')
-    elif ds_name == 'hope.pbr':
-        ds_dir = BOP_DS_DIR / 'hope'
-        ds = BOPDataset(ds_dir, split='train_pbr')
+    # elif ds_name == 'hope.pbr':
+    #     ds_dir = BOP_DS_DIR / 'hope'
+    #     ds = BOPDataset(ds_dir, split='train_pbr')
 
     elif ds_name == 'hb.val':
         ds_dir = BOP_DS_DIR / 'hb'

--- a/cosypose/scripts/download.py
+++ b/cosypose/scripts/download.py
@@ -48,6 +48,10 @@ BOP_DATASETS = {
     'tudl': {
         'splits': ['test_all', 'train_real']
     },
+
+    'hope': {
+        'splits': ['val', 'test_all']
+    },
 }
 
 BOP_DS_NAMES = list(BOP_DATASETS.keys())

--- a/cosypose/scripts/run_bop_inference.py
+++ b/cosypose/scripts/run_bop_inference.py
@@ -245,7 +245,7 @@ def main():
     if args.n_views > 1:
         ds_names = ['hb', 'tless', 'ycbv']
     else:
-        ds_names = ['hb', 'icbin', 'itodd', 'lmo', 'tless', 'tudl', 'ycbv']
+        ds_names = ['hb', 'icbin', 'itodd', 'lmo', 'tless', 'tudl', 'ycbv', 'hope']
 
     for ds_name in ds_names:
         this_cfg = deepcopy(cfg)

--- a/rclone.conf
+++ b/rclone.conf
@@ -2,5 +2,5 @@
 type = drive
 scope = drive.readonly
 root_folder_id = 1JmOYbu1oqN81Dlj2lh6NCAMrC8pEdAtD
-token = {"access_token":"ya29.a0AX9GBdVrXEpWAaIPK_hBGt08UObqBHBCHiHH4krxLasnMJTOV2DI6dc8Rq0f3MbC08D2rgHdDYIEmZj79AyDgahwRnupQbe4yNUe4SLZwHlcEz25JBtvT5f_BrWMpHPWHth6gZn7KeNv67FTV_Ic10yEiYn9BtwmswaCgYKATMSAQASFQHUCsbCJf5GvffzaeNsY1UTgc2CTg0169","token_type":"Bearer","refresh_token":"1//03Y__9oDQaadTCgYIARAAGAMSNwF-L9Ir1Ekfa8SGW8WupnLR2QsdRU0Su-QXIWeqAST-mbmtg2OGWB01vblv_GNyQXLjzD9b35A","expiry":"2023-01-20T21:34:50.683578414-06:00"}
+token = {"access_token":"ya29.a0AfH6SMC5mptNAOWZ_SZUhCy62ztZ9kqWbgGI8GpwAjACETpPavaMc1VCMfjDYlAXWZSLpAmygg8ppN9rqhsjtc0RI8yWVaVJtvHNfVVyHzJG2afrVuTsRq4czsDpJVJr2XaN19rlKsxp2ftG8BlcaxaujvRyawXT-CtfuA","token_type":"Bearer","refresh_token":"1//03Y__9oDQaadTCgYIARAAGAMSNwF-L9Ir1Ekfa8SGW8WupnLR2QsdRU0Su-QXIWeqAST-mbmtg2OGWB01vblv_GNyQXLjzD9b35A","expiry":"2020-08-16T16:01:06.690594859+02:00"}
 

--- a/rclone.conf
+++ b/rclone.conf
@@ -2,5 +2,5 @@
 type = drive
 scope = drive.readonly
 root_folder_id = 1JmOYbu1oqN81Dlj2lh6NCAMrC8pEdAtD
-token = {"access_token":"ya29.a0AfH6SMC5mptNAOWZ_SZUhCy62ztZ9kqWbgGI8GpwAjACETpPavaMc1VCMfjDYlAXWZSLpAmygg8ppN9rqhsjtc0RI8yWVaVJtvHNfVVyHzJG2afrVuTsRq4czsDpJVJr2XaN19rlKsxp2ftG8BlcaxaujvRyawXT-CtfuA","token_type":"Bearer","refresh_token":"1//03Y__9oDQaadTCgYIARAAGAMSNwF-L9Ir1Ekfa8SGW8WupnLR2QsdRU0Su-QXIWeqAST-mbmtg2OGWB01vblv_GNyQXLjzD9b35A","expiry":"2020-08-16T16:01:06.690594859+02:00"}
+token = {"access_token":"ya29.a0AX9GBdVrXEpWAaIPK_hBGt08UObqBHBCHiHH4krxLasnMJTOV2DI6dc8Rq0f3MbC08D2rgHdDYIEmZj79AyDgahwRnupQbe4yNUe4SLZwHlcEz25JBtvT5f_BrWMpHPWHth6gZn7KeNv67FTV_Ic10yEiYn9BtwmswaCgYKATMSAQASFQHUCsbCJf5GvffzaeNsY1UTgc2CTg0169","token_type":"Bearer","refresh_token":"1//03Y__9oDQaadTCgYIARAAGAMSNwF-L9Ir1Ekfa8SGW8WupnLR2QsdRU0Su-QXIWeqAST-mbmtg2OGWB01vblv_GNyQXLjzD9b35A","expiry":"2023-01-20T21:34:50.683578414-06:00"}
 


### PR DESCRIPTION
I've integrated the HOPE dataset (https://bop.felk.cvut.cz/datasets/#HOPE) into the necessary configs and BOP scripts.

I have verified that the following scripts result in a correctly formatted BOP submission file that achieves the expected scores in the BOP evaluation server:
```
python -m cosypose.scripts.download --bop_dataset=hope
python -m cosypose.scripts.convert_models_to_urdf --models=hope
# manually copied trained model weights
python -m cosypose.scripts.run_bop_inference --config bop-pbr --dataset hope
python -m cosypose.scripts.run_bop20_eval_multi --result_id=bop-pbr--383758 \
  --method=maskrcnn_detections/refiner/iteration=4 --convert_only
```

The final script (`cosypose.scripts.run_bop20_eval_multi`) does currently produce an error that I would like help to resolve:
```
Traceback (most recent call last):
  File "/home/big_white/miniconda3/envs/cosypose_SR/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/big_white/miniconda3/envs/cosypose_SR/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/big_white/code/cosypose_SR/cosypose/scripts/run_bop20_eval_multi.py", line 61, in <module>
    main()
  File "/home/big_white/code/cosypose_SR/cosypose/scripts/run_bop20_eval_multi.py", line 57, in main
    print(scores_path.read_text())
  File "/home/big_white/miniconda3/envs/cosypose_SR/lib/python3.7/pathlib.py", line 1216, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/home/big_white/miniconda3/envs/cosypose_SR/lib/python3.7/pathlib.py", line 1203, in open
    opener=self._opener)
  File "/home/big_white/miniconda3/envs/cosypose_SR/lib/python3.7/pathlib.py", line 1058, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/home/big_white/code/cosypose_SR/local_data/bop_eval_outputs/challenge2020-383758_hope-test/scores_bop19.json'
```

The following files need to be uploaded to the appropriate cloud drive for `cosypose.scripts.download` to work correctly:
* Trained model weights (https://drive.google.com/file/d/1ohQP6jFUwlidWwko4pNz5L-ubRz6FRl5/view?usp=sharing), to allow:
```
python -m cosypose.scripts.download detector-bop-hope-pbr--15246
python -m cosypose.scripts.download coarse-bop-hope-pbr--225203
python -m cosypose.scripts.download refiner-bop-hope-pbr--955392
```
* URDF meshes (https://drive.google.com/file/d/17A7AFh0Wc5YXQqkNnQxFCuBX4gHCZc1D/view?usp=sharing), to allow:
```
python -m cosypose.scripts.download --urdf_models=hope
```

PBR training images are not publicly available, so I have commented out the relevant settings in the HOPE config, e.g. in `cosypose/bop_config.py`:
```python
    # train_pbr_ds_name=[hope.pbr]
```