### PR TITLE
BOP inference on individual datasets

### DIFF
--- a/cosypose/scripts/run_bop_inference.py
+++ b/cosypose/scripts/run_bop_inference.py
@@ -193,7 +193,7 @@ def main():
     parser.add_argument('--id', default=-1, type=int)
     parser.add_argument('--config', default='bop-pbr', type=str)
     parser.add_argument('--nviews', dest='n_views', default=1, type=int)
-    parser.add_argument('--datasets', default=None, type=list)
+    parser.add_argument('--dataset', default=None, type=str)
     parser.add_argument('--icp', action='store_true')
     args = parser.parse_args()
 
@@ -248,10 +248,9 @@ def main():
     else:
         ds_names = ['hb', 'icbin', 'itodd', 'lmo', 'tless', 'tudl', 'ycbv']
     
-    if args.datasets is not None:
-        for ds_name in args.datasets:
-            assert ds_name in ds_names, f'{ds_name} not in {ds_names}'
-        ds_names = args.datasets
+    if args.dataset is not None:
+        assert args.dataset in ds_names, f'{args.dataset} not in {ds_names}'
+        ds_names = [args.dataset]
     
     for ds_name in ds_names:
         this_cfg = deepcopy(cfg)

--- a/cosypose/scripts/run_bop_inference.py
+++ b/cosypose/scripts/run_bop_inference.py
@@ -193,6 +193,7 @@ def main():
     parser.add_argument('--id', default=-1, type=int)
     parser.add_argument('--config', default='bop-pbr', type=str)
     parser.add_argument('--nviews', dest='n_views', default=1, type=int)
+    parser.add_argument('--datasets', default=None, type=list)
     parser.add_argument('--icp', action='store_true')
     args = parser.parse_args()
 
@@ -246,7 +247,12 @@ def main():
         ds_names = ['hb', 'tless', 'ycbv']
     else:
         ds_names = ['hb', 'icbin', 'itodd', 'lmo', 'tless', 'tudl', 'ycbv']
-
+    
+    if args.datasets is not None:
+        for ds_name in args.datasets:
+            assert ds_name in ds_names, f'{ds_name} not in {ds_names}'
+        ds_names = args.datasets
+    
     for ds_name in ds_names:
         this_cfg = deepcopy(cfg)
         this_cfg.ds_name = BOP_CONFIG[ds_name]['inference_ds_name'][0]


### PR DESCRIPTION
One last PR for today: I added support for a `--dataset` flag in the BOP inference script (`cosypose.scripts.run_bop_inference`) to allow inference on a single dataset at a time. When used as below, the submission file can be generated for a single dataset:
```
python -m cosypose.scripts.run_bop_inference --config bop-pbr --dataset DATASET
python -m cosypose.scripts.run_bop20_eval_multi --result_id=RESULT_ID \
  --method=maskrcnn_detections/refiner/iteration=4 --convert_only
```