### PR TITLE
Memory optimized dists_add_symmetric

### DIFF
--- a/cosypose/lib3d/distances.py
+++ b/cosypose/lib3d/distances.py
@@ -8,14 +8,12 @@ def dists_add(TXO_pred, TXO_gt, points):
     dists = TXO_gt_points - TXO_pred_points
     return dists
 
-
 def dists_add_symmetric(TXO_pred, TXO_gt, points):
     TXO_pred_points = transform_pts(TXO_pred, points)
     TXO_gt_points = transform_pts(TXO_gt, points)
-    dists = TXO_gt_points.unsqueeze(1) - TXO_pred_points.unsqueeze(2)
-    dists_norm_squared = (dists ** 2).sum(dim=-1)
-    assign = dists_norm_squared.argmin(dim=1)
-    ids_row = torch.arange(dists.shape[0]).unsqueeze(1).repeat(1, dists.shape[1])
-    ids_col = torch.arange(dists.shape[1]).unsqueeze(0).repeat(dists.shape[0], 1)
-    dists = dists[ids_row, assign, ids_col]
-    return dists
+    distances = torch.cdist(TXO_gt_points, TXO_pred_points,
+                            p=2, compute_mode='donot_use_mm_for_euclid_dist')
+    closest_points_idx = torch.argmin(distances, dim=2).squeeze()
+    TXO_pred_closest_to_gt = torch.index_select(TXO_pred_points, 1, closest_points_idx)
+    min_translations = TXO_gt_points - TXO_pred_closest_to_gt
+    return min_translations


### PR DESCRIPTION
I am proposing PR that fixes the issues on pretty old issues that mention 'CUDA out of memory error' upon running the evaluation script. 

I figured out that this issue comes from a single function;
It is cosypose.lib3d.distances.dist_add_symmetric

It allocates huge tensors for intermediate computations. Of sizes NxNx3 and NxNx1 where the N is the number of points.

Yet the same could be achieved by rewriting the code a little bit.

Alternative solutions are also possible and working(tested). Those approaches are tested, but this proposal looks better to me:
- converting tensors to float16 
- computing the distances pointwise (too long, on CPU even worse)
- computing in batches of points (another parameter, still slower)


This solution uses **<0.25** of the original version's memory:
![MemExperiments](https://user-images.githubusercontent.com/17781705/231282725-956f7bfb-2302-4c7d-a50b-2951a83165d0.png)


_Also, some distance functions from lib3d.symmetric_distances.py could be optimized with this approach._
